### PR TITLE
Style update

### DIFF
--- a/ControlsKit.xcodeproj/project.pbxproj
+++ b/ControlsKit.xcodeproj/project.pbxproj
@@ -44,29 +44,29 @@
 
 /* Begin PBXFileReference section */
 		F42804551ECC5DD600185741 /* ControlsKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ControlsKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		F42804581ECC5DD600185741 /* ControlsKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ControlsKit.h; sourceTree = "<group>"; };
+		F42804581ECC5DD600185741 /* ControlsKit.h */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.c.h; path = ControlsKit.h; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
 		F42804591ECC5DD600185741 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		F42804601ECC622A00185741 /* CTKNibView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CTKNibView.h; sourceTree = "<group>"; };
-		F42804611ECC622A00185741 /* CTKNibView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CTKNibView.m; sourceTree = "<group>"; };
-		F42804621ECC622A00185741 /* CTKPageControl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CTKPageControl.h; sourceTree = "<group>"; };
-		F42804631ECC622A00185741 /* CTKPageControl.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CTKPageControl.m; sourceTree = "<group>"; };
-		F42804641ECC622A00185741 /* CTKPlaceholderTextView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CTKPlaceholderTextView.h; sourceTree = "<group>"; };
-		F42804651ECC622A00185741 /* CTKPlaceholderTextView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CTKPlaceholderTextView.m; sourceTree = "<group>"; };
-		F42804661ECC622A00185741 /* CTKSwitch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CTKSwitch.h; sourceTree = "<group>"; };
-		F42804671ECC622A00185741 /* CTKSwitch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CTKSwitch.m; sourceTree = "<group>"; };
+		F42804601ECC622A00185741 /* CTKNibView.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.h; path = CTKNibView.h; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
+		F42804611ECC622A00185741 /* CTKNibView.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = CTKNibView.m; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
+		F42804621ECC622A00185741 /* CTKPageControl.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.h; path = CTKPageControl.h; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
+		F42804631ECC622A00185741 /* CTKPageControl.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = CTKPageControl.m; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
+		F42804641ECC622A00185741 /* CTKPlaceholderTextView.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.h; path = CTKPlaceholderTextView.h; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
+		F42804651ECC622A00185741 /* CTKPlaceholderTextView.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = CTKPlaceholderTextView.m; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
+		F42804661ECC622A00185741 /* CTKSwitch.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.h; path = CTKSwitch.h; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
+		F42804671ECC622A00185741 /* CTKSwitch.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = CTKSwitch.m; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
 		F42804741ECC636700185741 /* ControlsKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ControlsKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F42804781ECC636700185741 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		F428047F1ECC638900185741 /* NibViewTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NibViewTest.h; sourceTree = "<group>"; };
-		F42804801ECC638900185741 /* NibViewTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NibViewTest.m; sourceTree = "<group>"; };
+		F428047F1ECC638900185741 /* NibViewTest.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.h; path = NibViewTest.h; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
+		F42804801ECC638900185741 /* NibViewTest.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = NibViewTest.m; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
 		F42804811ECC638900185741 /* NibViewTest.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = NibViewTest.xib; sourceTree = "<group>"; };
-		F42804821ECC638900185741 /* NibViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NibViewTests.m; sourceTree = "<group>"; };
-		F42804831ECC638900185741 /* PageControlTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PageControlTests.m; sourceTree = "<group>"; };
-		F42804841ECC638900185741 /* PlaceholderTextViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PlaceholderTextViewTests.m; sourceTree = "<group>"; };
-		F42804851ECC638900185741 /* SwitchTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SwitchTests.m; sourceTree = "<group>"; };
+		F42804821ECC638900185741 /* NibViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = NibViewTests.m; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
+		F42804831ECC638900185741 /* PageControlTests.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = PageControlTests.m; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
+		F42804841ECC638900185741 /* PlaceholderTextViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = PlaceholderTextViewTests.m; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
+		F42804851ECC638900185741 /* SwitchTests.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = SwitchTests.m; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
 		F42804861ECC638900185741 /* Tests.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Tests.storyboard; sourceTree = "<group>"; };
 		F42804871ECC638900185741 /* Tests.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Tests.xcassets; sourceTree = "<group>"; };
-		F42804881ECC638900185741 /* TestViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestViewController.h; sourceTree = "<group>"; };
-		F42804891ECC638900185741 /* TestViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestViewController.m; sourceTree = "<group>"; };
+		F42804881ECC638900185741 /* TestViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.h; path = TestViewController.h; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
+		F42804891ECC638900185741 /* TestViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = TestViewController.m; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
 		F42804BE1ECC88BC00185741 /* NibView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NibView.swift; sourceTree = "<group>"; };
 		F42804C01ECC88C200185741 /* PageControl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PageControl.swift; sourceTree = "<group>"; };
 		F42804C21ECC88CC00185741 /* PlaceholderTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaceholderTextView.swift; sourceTree = "<group>"; };
@@ -100,6 +100,7 @@
 				F42804561ECC5DD600185741 /* Products */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 1;
 		};
 		F42804561ECC5DD600185741 /* Products */ = {
 			isa = PBXGroup;

--- a/ControlsKit/CTKNibView.m
+++ b/ControlsKit/CTKNibView.m
@@ -48,7 +48,7 @@
 - (id)initWithCoder:(NSCoder *)aDecoder {
   self = [super initWithCoder:aDecoder];
   if (self) {
-    
+
   }
   return self;
 }
@@ -63,7 +63,7 @@
 }
 
 - (NSString *)nibName {
-  NSString * baseName = NSStringFromClass([self class]);
+  NSString *baseName = NSStringFromClass([self class]);
   NSRange rangeOfDot = [baseName rangeOfString:@"."];
   return rangeOfDot.location == NSNotFound ? baseName : [baseName substringFromIndex:rangeOfDot.location + 1];
 }
@@ -78,7 +78,7 @@
 
 - (void)awakeFromNib {
   [super awakeFromNib];
-  
+
   self.shouldAwakeFromNib = NO;
   [self createFromNib];
 }
@@ -94,15 +94,15 @@
       [self awakeFromNib];
 #pragma clang diagnostic pop
     }
-    
+
     self.contentView.translatesAutoresizingMaskIntoConstraints = NO;
     [self addSubview:self.contentView];
-    
-    NSLayoutConstraint * leadingConstraint = [NSLayoutConstraint constraintWithItem:self.contentView attribute:NSLayoutAttributeLeading relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeLeading multiplier:1.0 constant:0.0];
-    NSLayoutConstraint * topConstraint = [NSLayoutConstraint constraintWithItem:self.contentView attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeTop multiplier:1.0 constant:0.0];
-    NSLayoutConstraint * trailingConstraint = [NSLayoutConstraint constraintWithItem:self.contentView attribute:NSLayoutAttributeTrailing relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeTrailing multiplier:1.0 constant:0.0];
-    NSLayoutConstraint * bottomConstraint = [NSLayoutConstraint constraintWithItem:self.contentView attribute:NSLayoutAttributeBottom relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeBottom multiplier:1.0 constant:0.0];
-    
+
+    NSLayoutConstraint *leadingConstraint = [NSLayoutConstraint constraintWithItem:self.contentView attribute:NSLayoutAttributeLeading relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeLeading multiplier:1.0 constant:0.0];
+    NSLayoutConstraint *topConstraint = [NSLayoutConstraint constraintWithItem:self.contentView attribute:NSLayoutAttributeTop relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeTop multiplier:1.0 constant:0.0];
+    NSLayoutConstraint *trailingConstraint = [NSLayoutConstraint constraintWithItem:self.contentView attribute:NSLayoutAttributeTrailing relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeTrailing multiplier:1.0 constant:0.0];
+    NSLayoutConstraint *bottomConstraint = [NSLayoutConstraint constraintWithItem:self.contentView attribute:NSLayoutAttributeBottom relatedBy:NSLayoutRelationEqual toItem:self attribute:NSLayoutAttributeBottom multiplier:1.0 constant:0.0];
+
     [self addConstraints:@[leadingConstraint, topConstraint, trailingConstraint, bottomConstraint]];
   }
 }

--- a/ControlsKit/CTKPlaceholderTextView.m
+++ b/ControlsKit/CTKPlaceholderTextView.m
@@ -38,19 +38,19 @@ const UIEdgeInsets kCTKPlaceholderTextViewDefaultPlaceholderInset = {8.0f, 4.0f,
 
 - (id)initWithFrame:(CGRect)frame {
 	if (self = [super initWithFrame:frame]) {
-		[self commonInit];
+		[self ctk_commonInit];
 	}
 	return self;
 }
 
 - (id)initWithCoder:(NSCoder *)aDecoder {
 	if (self = [super initWithCoder:aDecoder]) {
-		[self commonInit];
+		[self ctk_commonInit];
 	}
 	return self;
 }
 
-- (void)commonInit {
+- (void)ctk_commonInit {
 	_placeholderInsets = kCTKPlaceholderTextViewDefaultPlaceholderInset;
 
 	_placeholderLabel = [[UILabel alloc] init];
@@ -60,15 +60,15 @@ const UIEdgeInsets kCTKPlaceholderTextViewDefaultPlaceholderInset = {8.0f, 4.0f,
 	[self updatePlaceholderFrame];
 
 	[[NSNotificationCenter defaultCenter] addObserver:self
-																					 selector:@selector(handleTextViewDidBeginEditing:)
+																					 selector:@selector(updatePlaceholderVisibilityFromNotification:)
 																							 name:UITextViewTextDidBeginEditingNotification
 																						 object:self];
 	[[NSNotificationCenter defaultCenter] addObserver:self
-																					 selector:@selector(handleTextViewDidChange:)
+																					 selector:@selector(updatePlaceholderVisibilityFromNotification:)
 																							 name:UITextViewTextDidChangeNotification
 																						 object:self];
 	[[NSNotificationCenter defaultCenter] addObserver:self
-																					 selector:@selector(handleTextViewDidEndEditing:)
+																					 selector:@selector(updatePlaceholderVisibilityFromNotification:)
 																							 name:UITextViewTextDidEndEditingNotification
 																						 object:self];
 }
@@ -80,7 +80,7 @@ const UIEdgeInsets kCTKPlaceholderTextViewDefaultPlaceholderInset = {8.0f, 4.0f,
 - (void)setText:(NSString *)text {
 	[super setText:text];
 
-	[self updatePlaceholderVisibility];
+	[self updatePlaceholderVisibilityFromNotification:nil];
 }
 
 - (void)layoutSubviews {
@@ -125,19 +125,7 @@ const UIEdgeInsets kCTKPlaceholderTextViewDefaultPlaceholderInset = {8.0f, 4.0f,
 	[self updatePlaceholderFrame];
 }
 
-- (void)handleTextViewDidBeginEditing:(NSNotification *)notification {
-	[self updatePlaceholderVisibility];
-}
-
-- (void)handleTextViewDidChange:(NSNotification *)notification {
-	[self updatePlaceholderVisibility];
-}
-
-- (void)handleTextViewDidEndEditing:(NSNotification *)notification {
-	[self updatePlaceholderVisibility];
-}
-
-- (void)updatePlaceholderVisibility {
+- (void)updatePlaceholderVisibilityFromNotification:(NSNotification *)notification {
 	self.placeholderLabel.hidden = self.text.length > 0;
 	[self sendSubviewToBack:self.placeholderLabel];
 }

--- a/ControlsKit/CTKPlaceholderTextView.m
+++ b/ControlsKit/CTKPlaceholderTextView.m
@@ -37,97 +37,97 @@ const UIEdgeInsets kCTKPlaceholderTextViewDefaultPlaceholderInset = {8.0f, 4.0f,
 @implementation CTKPlaceholderTextView
 
 - (id)initWithFrame:(CGRect)frame {
-	if (self = [super initWithFrame:frame]) {
-		[self ctk_commonInit];
-	}
-	return self;
+  if (self = [super initWithFrame:frame]) {
+    [self ctk_commonInit];
+  }
+  return self;
 }
 
 - (id)initWithCoder:(NSCoder *)aDecoder {
-	if (self = [super initWithCoder:aDecoder]) {
-		[self ctk_commonInit];
-	}
-	return self;
+  if (self = [super initWithCoder:aDecoder]) {
+    [self ctk_commonInit];
+  }
+  return self;
 }
 
 - (void)ctk_commonInit {
-	_placeholderInsets = kCTKPlaceholderTextViewDefaultPlaceholderInset;
+  _placeholderInsets = kCTKPlaceholderTextViewDefaultPlaceholderInset;
 
-	_placeholderLabel = [[UILabel alloc] init];
-	_placeholderLabel.font = self.font;
+  _placeholderLabel = [[UILabel alloc] init];
+  _placeholderLabel.font = self.font;
 
-	[self addSubview:_placeholderLabel];
-	[self updatePlaceholderFrame];
+  [self addSubview:_placeholderLabel];
+  [self updatePlaceholderFrame];
 
-	[[NSNotificationCenter defaultCenter] addObserver:self
-																					 selector:@selector(updatePlaceholderVisibilityFromNotification:)
-																							 name:UITextViewTextDidBeginEditingNotification
-																						 object:self];
-	[[NSNotificationCenter defaultCenter] addObserver:self
-																					 selector:@selector(updatePlaceholderVisibilityFromNotification:)
-																							 name:UITextViewTextDidChangeNotification
-																						 object:self];
-	[[NSNotificationCenter defaultCenter] addObserver:self
-																					 selector:@selector(updatePlaceholderVisibilityFromNotification:)
-																							 name:UITextViewTextDidEndEditingNotification
-																						 object:self];
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(updatePlaceholderVisibilityFromNotification:)
+                                               name:UITextViewTextDidBeginEditingNotification
+                                             object:self];
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(updatePlaceholderVisibilityFromNotification:)
+                                               name:UITextViewTextDidChangeNotification
+                                             object:self];
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(updatePlaceholderVisibilityFromNotification:)
+                                               name:UITextViewTextDidEndEditingNotification
+                                             object:self];
 }
 
 - (void)dealloc {
-	[[NSNotificationCenter defaultCenter] removeObserver:self];
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
 - (void)setText:(NSString *)text {
-	[super setText:text];
+  [super setText:text];
 
-	[self updatePlaceholderVisibilityFromNotification:nil];
+  [self updatePlaceholderVisibilityFromNotification:nil];
 }
 
 - (void)layoutSubviews {
-	[super layoutSubviews];
+  [super layoutSubviews];
 
-	[self updatePlaceholderFrame];
+  [self updatePlaceholderFrame];
 }
 
 - (void)updatePlaceholderFrame {
-	self.placeholderLabel.frame = UIEdgeInsetsInsetRect(self.bounds, self.placeholderInsets);
+  self.placeholderLabel.frame = UIEdgeInsetsInsetRect(self.bounds, self.placeholderInsets);
 }
 
 - (void)setFont:(UIFont *)font {
-	[super setFont:font];
+  [super setFont:font];
 
-	self.placeholderLabel.font = font;
+  self.placeholderLabel.font = font;
 }
 
 - (NSString *)placeholder {
-	return self.placeholderLabel.text;
+  return self.placeholderLabel.text;
 }
 
 - (void)setPlaceholder:(NSString *)placeholder {
-	self.placeholderLabel.text = placeholder;
+  self.placeholderLabel.text = placeholder;
 
-	[self updatePlaceholderFrame];
+  [self updatePlaceholderFrame];
 }
 
 - (NSAttributedString *)attributedPlaceholder {
-	return self.placeholderLabel.attributedText;
+  return self.placeholderLabel.attributedText;
 }
 
 - (void)setAttributedPlaceholder:(NSAttributedString *)attributedPlaceholder {
-	self.placeholderLabel.attributedText = attributedPlaceholder;
+  self.placeholderLabel.attributedText = attributedPlaceholder;
 
-	[self updatePlaceholderFrame];
+  [self updatePlaceholderFrame];
 }
 
 - (void)setPlaceholderInsets:(UIEdgeInsets)placeholderInsets {
-	_placeholderInsets = placeholderInsets;
-
-	[self updatePlaceholderFrame];
+  _placeholderInsets = placeholderInsets;
+  
+  [self updatePlaceholderFrame];
 }
 
 - (void)updatePlaceholderVisibilityFromNotification:(NSNotification *)notification {
-	self.placeholderLabel.hidden = self.text.length > 0;
-	[self sendSubviewToBack:self.placeholderLabel];
+  self.placeholderLabel.hidden = self.text.length > 0;
+  [self sendSubviewToBack:self.placeholderLabel];
 }
 
 @end

--- a/ControlsKitExample.xcodeproj/project.pbxproj
+++ b/ControlsKitExample.xcodeproj/project.pbxproj
@@ -42,10 +42,10 @@
 		F42804AB1ECC66BD00185741 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		F42804AD1ECC66BD00185741 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F42804B31ECC66CC00185741 /* ControlsKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ControlsKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		F42804B81ECC6FD700185741 /* SwitchViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SwitchViewController.h; sourceTree = "<group>"; };
-		F42804B91ECC6FD700185741 /* SwitchViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SwitchViewController.m; sourceTree = "<group>"; };
-		F42804BB1ECC72DB00185741 /* PageControlViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PageControlViewController.h; sourceTree = "<group>"; };
-		F42804BC1ECC72DB00185741 /* PageControlViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PageControlViewController.m; sourceTree = "<group>"; };
+		F42804B81ECC6FD700185741 /* SwitchViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.h; path = SwitchViewController.h; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
+		F42804B91ECC6FD700185741 /* SwitchViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = SwitchViewController.m; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
+		F42804BB1ECC72DB00185741 /* PageControlViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.h; path = PageControlViewController.h; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
+		F42804BC1ECC72DB00185741 /* PageControlViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.c.objc; path = PageControlViewController.m; sourceTree = "<group>"; tabWidth = 2; usesTabs = 0; };
 		F476541C1ECC998F0066A20C /* HeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HeaderView.swift; sourceTree = "<group>"; };
 		F476541D1ECC998F0066A20C /* HeaderView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = HeaderView.xib; sourceTree = "<group>"; };
 		F47654221ECC9C820066A20C /* NibViewViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NibViewViewController.swift; sourceTree = "<group>"; };
@@ -71,6 +71,7 @@
 				F428049D1ECC66BD00185741 /* Products */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 1;
 		};
 		F428049D1ECC66BD00185741 /* Products */ = {
 			isa = PBXGroup;

--- a/ControlsKitExample/PageControlViewController.m
+++ b/ControlsKitExample/PageControlViewController.m
@@ -38,15 +38,15 @@
 
 @interface PageControlViewController () <UIScrollViewDelegate>
 
-@property (weak, nonatomic) IBOutlet UIScrollView *scrollView;
-@property (weak, nonatomic) IBOutlet CTKPageControl *pageControl;
-@property (weak, nonatomic) IBOutlet UISwitch *setCustomImagesSwitch;
-@property (weak, nonatomic) IBOutlet UISwitch *setCustomColorsSwitch;
-@property (weak, nonatomic) IBOutlet UISwitch *applyTintToImagesSwitch;
-@property (weak, nonatomic) IBOutlet UISlider *dotsSpaceSlider;
-@property (weak, nonatomic) IBOutlet UILabel *dotsSpaceCurrentValueLabel;
-@property (weak, nonatomic) IBOutlet UIStepper *numberOfDotsStepper;
-@property (weak, nonatomic) IBOutlet UILabel *numberOfDotsCurrentValueLabel;
+@property (strong, nonatomic) IBOutlet UIScrollView *scrollView;
+@property (strong, nonatomic) IBOutlet CTKPageControl *pageControl;
+@property (strong, nonatomic) IBOutlet UISwitch *setCustomImagesSwitch;
+@property (strong, nonatomic) IBOutlet UISwitch *setCustomColorsSwitch;
+@property (strong, nonatomic) IBOutlet UISwitch *applyTintToImagesSwitch;
+@property (strong, nonatomic) IBOutlet UISlider *dotsSpaceSlider;
+@property (strong, nonatomic) IBOutlet UILabel *dotsSpaceCurrentValueLabel;
+@property (strong, nonatomic) IBOutlet UIStepper *numberOfDotsStepper;
+@property (strong, nonatomic) IBOutlet UILabel *numberOfDotsCurrentValueLabel;
 
 @end
 

--- a/ControlsKitExample/PageControlViewController.m
+++ b/ControlsKitExample/PageControlViewController.m
@@ -54,13 +54,13 @@
 
 - (void)viewDidLoad {
   [super viewDidLoad];
-  
+
   [self.dotsSpaceSlider addTarget:self action:@selector(dotsSpaceSliderDidChange:) forControlEvents:UIControlEventValueChanged];
   self.dotsSpaceSlider.minimumValue = kPageControlDotsMinSpace;
   self.dotsSpaceSlider.maximumValue = kPageControlDotsMaxSpace;
   self.dotsSpaceSlider.value = kPageControlDotsSpaceDefaultValue;
   self.dotsSpaceCurrentValueLabel.text = [NSString stringWithFormat:@"%.2f", self.dotsSpaceSlider.value];
-  
+
   [self.numberOfDotsStepper addTarget:self action:@selector(numberOfDotsStepperDidChange:) forControlEvents:UIControlEventValueChanged];
   self.numberOfDotsStepper.minimumValue = kNumberOfDotsMinValue;
   self.numberOfDotsStepper.maximumValue = kNumberOfDotsMaxValue;
@@ -70,7 +70,7 @@
 
 - (void)viewDidAppear:(BOOL)animated {
   [super viewDidAppear:animated];
-  
+
   [self setupColorViewsToDisplay];
 }
 
@@ -78,19 +78,19 @@
   if (theSwitch.isOn) {
     self.pageControl.leftDotImageActive = [UIImage imageNamed:@"Carousel-Left-Active"];
     self.pageControl.leftDotImageInactive = [UIImage imageNamed:@"Carousel-Left-Inactive"];
-    
+
     self.pageControl.middleDotImageActive = [UIImage imageNamed:@"Carousel-Middle-Active"];
     self.pageControl.middleDotImageInactive = [UIImage imageNamed:@"Carousel-Middle-Inactive"];
-    
+
     self.pageControl.rightDotImageActive = [UIImage imageNamed:@"Carousel-Right-Active"];
     self.pageControl.rightDotImageInactive = [UIImage imageNamed:@"Carousel-Right-Inactive"];
   } else {
     self.pageControl.leftDotImageActive = nil;
     self.pageControl.leftDotImageInactive = nil;
-    
+
     self.pageControl.middleDotImageActive = nil;
     self.pageControl.middleDotImageInactive = nil;
-    
+
     self.pageControl.rightDotImageActive = nil;
     self.pageControl.rightDotImageInactive = nil;
   }
@@ -139,15 +139,15 @@
 
 - (void)setupColorViewsToDisplay {
   NSArray *colorsArray = [[NSArray alloc] initWithObjects:[UIColor orangeColor], [UIColor magentaColor], [UIColor purpleColor], [UIColor brownColor], [UIColor cyanColor], nil];
-  
+
   self.pageControl.numberOfPages = colorsArray.count;
-  
+
   for (NSInteger i = 0; i < [colorsArray count]; i++) {
     UIView *contentView = [[UIImageView alloc] initWithFrame:CGRectMake(self.scrollView.frame.size.width * i, 0.0f, self.scrollView.frame.size.width, self.scrollView.frame.size.height)];
     contentView.backgroundColor = colorsArray[i];
     [self.scrollView addSubview:contentView];
   }
-  
+
   self.scrollView.contentSize = CGSizeMake(self.scrollView.frame.size.width * colorsArray.count, self.scrollView.frame.size.height);
 }
 

--- a/ControlsKitExample/SwitchViewController.m
+++ b/ControlsKitExample/SwitchViewController.m
@@ -47,13 +47,13 @@
 
 - (void)viewDidLoad {
   [super viewDidLoad];
-  
+
   [self.applyBackgroundImageSwitchOn addTarget:self action:@selector(applyBackgroundImageSwitchOnDidChange:) forControlEvents:UIControlEventValueChanged];
   [self.applyBackgroundImageSwitchOff addTarget:self action:@selector(applyBackgroundImageSwitchOffDidChange:) forControlEvents:UIControlEventValueChanged];
-  
+
   [self.applyBackgroundColorSwitchOn addTarget:self action:@selector(applyBackgroundColorSwitchOnDidChange:) forControlEvents:UIControlEventValueChanged];
   [self.applyBackgroundColorSwitchOff addTarget:self action:@selector(applyBackgroundColorSwitchOffDidChange:) forControlEvents:UIControlEventValueChanged];
-  
+
   [self.applyForegroundColorSwitch addTarget:self action:@selector(applyForegroundColorSwitchDidChange:) forControlEvents:UIControlEventValueChanged];
 }
 

--- a/ControlsKitExample/SwitchViewController.m
+++ b/ControlsKitExample/SwitchViewController.m
@@ -30,16 +30,16 @@
 
 @interface SwitchViewController ()
 
-@property (weak, nonatomic) IBOutlet UIScrollView *scrollView;
-@property (weak, nonatomic) IBOutlet CTKSwitch *customSwitch;
+@property (strong, nonatomic) IBOutlet UIScrollView *scrollView;
+@property (strong, nonatomic) IBOutlet CTKSwitch *customSwitch;
 
-@property (weak, nonatomic) IBOutlet UISwitch *applyBackgroundImageSwitchOn;
-@property (weak, nonatomic) IBOutlet UISwitch *applyBackgroundImageSwitchOff;
+@property (strong, nonatomic) IBOutlet UISwitch *applyBackgroundImageSwitchOn;
+@property (strong, nonatomic) IBOutlet UISwitch *applyBackgroundImageSwitchOff;
 
-@property (weak, nonatomic) IBOutlet UISwitch *applyBackgroundColorSwitchOn;
-@property (weak, nonatomic) IBOutlet UISwitch *applyBackgroundColorSwitchOff;
+@property (strong, nonatomic) IBOutlet UISwitch *applyBackgroundColorSwitchOn;
+@property (strong, nonatomic) IBOutlet UISwitch *applyBackgroundColorSwitchOff;
 
-@property (weak, nonatomic) IBOutlet UISwitch *applyForegroundColorSwitch;
+@property (strong, nonatomic) IBOutlet UISwitch *applyForegroundColorSwitch;
 
 @end
 

--- a/ControlsKitTests/NibViewTests.m
+++ b/ControlsKitTests/NibViewTests.m
@@ -37,7 +37,7 @@
 
 - (void)testNibViewInit {
   NibViewTest * nibView = [[NibViewTest alloc] init];
-  
+
   XCTAssertNotNil(nibView.contentView);
   XCTAssertNotNil(nibView.label);
   XCTAssertTrue([nibView.label isKindOfClass:[UILabel class]]);
@@ -45,7 +45,7 @@
 
 - (void)testNibViewInitWithFrame {
   NibViewTest * nibView = [[NibViewTest alloc] initWithFrame:CGRectZero];
-  
+
   XCTAssertNotNil(nibView.contentView);
   XCTAssertNotNil(nibView.label);
   XCTAssertTrue([nibView.label isKindOfClass:[UILabel class]]);
@@ -55,7 +55,7 @@
   UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Tests" bundle:[NSBundle bundleForClass:[self class]]];
   TestViewController *testViewController = [storyboard instantiateViewControllerWithIdentifier:@"TestsViewControllerID"];
   [testViewController loadView];
-  
+
   XCTAssertNotNil(testViewController.testNibView);
   XCTAssertTrue([testViewController.testNibView isKindOfClass:[CTKNibView class]]);
   XCTAssertNotNil(testViewController.testNibView.contentView);

--- a/ControlsKitTests/PlaceholderTextViewTests.m
+++ b/ControlsKitTests/PlaceholderTextViewTests.m
@@ -41,7 +41,7 @@
 @dynamic placeholderLabel;
 
 - (void)userSetText:(NSString *)text {
-	[super setText:text];
+  [super setText:text];
 }
 
 @end
@@ -53,70 +53,70 @@
 @implementation PlaceholderTextViewTests
 
 - (void)testPlaceholderInitWithFrame {
-	CTKPlaceholderTextView * textView = [[CTKPlaceholderTextView alloc] initWithFrame:CGRectZero];
-	XCTAssertFalse(textView.placeholderLabel.hidden);
-	textView.text = @"placeholder should disappear";
-	XCTAssertTrue(textView.placeholderLabel.hidden);
-	textView.text = @"";
-	XCTAssertFalse(textView.placeholderLabel.hidden);
+  CTKPlaceholderTextView * textView = [[CTKPlaceholderTextView alloc] initWithFrame:CGRectZero];
+  XCTAssertFalse(textView.placeholderLabel.hidden);
+  textView.text = @"placeholder should disappear";
+  XCTAssertTrue(textView.placeholderLabel.hidden);
+  textView.text = @"";
+  XCTAssertFalse(textView.placeholderLabel.hidden);
 }
 
 - (void)testPlaceholderInitWithCoder {
-	UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Tests" bundle:[NSBundle bundleForClass:[self class]]];
-	TestViewController *testViewController = [storyboard instantiateViewControllerWithIdentifier:@"TestsViewControllerID"];
-	[testViewController loadView];
-	
-	XCTAssertNotNil(testViewController.testPlaceholderTextView);
-	XCTAssertFalse(testViewController.testPlaceholderTextView.placeholderLabel.hidden);
-	testViewController.testPlaceholderTextView.text = @"placeholder should disappear";
-	XCTAssertTrue(testViewController.testPlaceholderTextView.placeholderLabel.hidden);
-	testViewController.testPlaceholderTextView.text = @"";
-	XCTAssertFalse(testViewController.testPlaceholderTextView.placeholderLabel.hidden);
+  UIStoryboard *storyboard = [UIStoryboard storyboardWithName:@"Tests" bundle:[NSBundle bundleForClass:[self class]]];
+  TestViewController *testViewController = [storyboard instantiateViewControllerWithIdentifier:@"TestsViewControllerID"];
+  [testViewController loadView];
+
+  XCTAssertNotNil(testViewController.testPlaceholderTextView);
+  XCTAssertFalse(testViewController.testPlaceholderTextView.placeholderLabel.hidden);
+  testViewController.testPlaceholderTextView.text = @"placeholder should disappear";
+  XCTAssertTrue(testViewController.testPlaceholderTextView.placeholderLabel.hidden);
+  testViewController.testPlaceholderTextView.text = @"";
+  XCTAssertFalse(testViewController.testPlaceholderTextView.placeholderLabel.hidden);
 }
 
 - (void)testPlaceholderPosition {
-	CTKPlaceholderTextView * textView = [[CTKPlaceholderTextView alloc] initWithFrame:CGRectMake(0.0f, 0.0f, 50.0f, 50.0f)];
-	XCTAssertEqual(textView.placeholderLabel.frame.origin.x, kCTKPlaceholderTextViewDefaultPlaceholderInset.left);
-	textView.text = @"Text";
-	XCTAssertEqual(textView.placeholderLabel.frame.origin.x, kCTKPlaceholderTextViewDefaultPlaceholderInset.left);
-	textView.placeholderInsets = UIEdgeInsetsMake(0.0f, 0.0f, 0.0f, 5.0f);
-	XCTAssertEqual(textView.placeholderLabel.frame.size.width, 45.0f);
-	textView.placeholderInsets = UIEdgeInsetsMake(0.0f, 0.0f, 0.0f, 0.0f);
-	textView.frame = CGRectMake(0.0f, 0.0f, 30.0f, 30.0f);
-	[textView layoutIfNeeded];
-	XCTAssertEqual(textView.placeholderLabel.frame.size.width, 30.0f);
+  CTKPlaceholderTextView * textView = [[CTKPlaceholderTextView alloc] initWithFrame:CGRectMake(0.0f, 0.0f, 50.0f, 50.0f)];
+  XCTAssertEqual(textView.placeholderLabel.frame.origin.x, kCTKPlaceholderTextViewDefaultPlaceholderInset.left);
+  textView.text = @"Text";
+  XCTAssertEqual(textView.placeholderLabel.frame.origin.x, kCTKPlaceholderTextViewDefaultPlaceholderInset.left);
+  textView.placeholderInsets = UIEdgeInsetsMake(0.0f, 0.0f, 0.0f, 5.0f);
+  XCTAssertEqual(textView.placeholderLabel.frame.size.width, 45.0f);
+  textView.placeholderInsets = UIEdgeInsetsMake(0.0f, 0.0f, 0.0f, 0.0f);
+  textView.frame = CGRectMake(0.0f, 0.0f, 30.0f, 30.0f);
+  [textView layoutIfNeeded];
+  XCTAssertEqual(textView.placeholderLabel.frame.size.width, 30.0f);
 }
 
 - (void)testPlaceholderText {
-	CTKPlaceholderTextView * textView = [[CTKPlaceholderTextView alloc] initWithFrame:CGRectZero];
-	textView.placeholder = @"test";
-	XCTAssertEqualObjects(textView.placeholder, @"test");
-	XCTAssertEqualObjects(textView.placeholderLabel.text, textView.placeholder);
-	NSAttributedString * test = [[NSAttributedString alloc] initWithString:@"test"];
-	textView.attributedPlaceholder = test;
-	XCTAssertEqualObjects(textView.attributedPlaceholder, test);
-	XCTAssertEqualObjects(textView.placeholderLabel.attributedText, test);
+  CTKPlaceholderTextView * textView = [[CTKPlaceholderTextView alloc] initWithFrame:CGRectZero];
+  textView.placeholder = @"test";
+  XCTAssertEqualObjects(textView.placeholder, @"test");
+  XCTAssertEqualObjects(textView.placeholderLabel.text, textView.placeholder);
+  NSAttributedString * test = [[NSAttributedString alloc] initWithString:@"test"];
+  textView.attributedPlaceholder = test;
+  XCTAssertEqualObjects(textView.attributedPlaceholder, test);
+  XCTAssertEqualObjects(textView.placeholderLabel.attributedText, test);
 }
 
 - (void)testPlaceholderVisibility {
-	CTKPlaceholderTextView * textView = [[CTKPlaceholderTextView alloc] initWithFrame:CGRectZero];
-	XCTAssertFalse(textView.placeholderLabel.hidden);
-	textView.text = @"test";
-	XCTAssertTrue(textView.placeholderLabel.hidden);
-	textView.text = nil;
-	XCTAssertFalse(textView.placeholderLabel.hidden);
-	[[NSNotificationCenter defaultCenter] postNotificationName:UITextViewTextDidBeginEditingNotification object:textView userInfo:nil];
-	XCTAssertFalse(textView.placeholderLabel.hidden);
-	[textView userSetText:@"t"];
-	XCTAssertFalse(textView.placeholderLabel.hidden);
-	[[NSNotificationCenter defaultCenter] postNotificationName:UITextViewTextDidChangeNotification object:textView userInfo:nil];
-	XCTAssertTrue(textView.placeholderLabel.hidden);
-	[textView userSetText:@""];
-	XCTAssertTrue(textView.placeholderLabel.hidden);
-	[[NSNotificationCenter defaultCenter] postNotificationName:UITextViewTextDidChangeNotification object:textView userInfo:nil];
-	XCTAssertFalse(textView.placeholderLabel.hidden);
-	[[NSNotificationCenter defaultCenter] postNotificationName:UITextViewTextDidEndEditingNotification object:textView userInfo:nil];
-	XCTAssertFalse(textView.placeholderLabel.hidden);
+  CTKPlaceholderTextView * textView = [[CTKPlaceholderTextView alloc] initWithFrame:CGRectZero];
+  XCTAssertFalse(textView.placeholderLabel.hidden);
+  textView.text = @"test";
+  XCTAssertTrue(textView.placeholderLabel.hidden);
+  textView.text = nil;
+  XCTAssertFalse(textView.placeholderLabel.hidden);
+  [[NSNotificationCenter defaultCenter] postNotificationName:UITextViewTextDidBeginEditingNotification object:textView userInfo:nil];
+  XCTAssertFalse(textView.placeholderLabel.hidden);
+  [textView userSetText:@"t"];
+  XCTAssertFalse(textView.placeholderLabel.hidden);
+  [[NSNotificationCenter defaultCenter] postNotificationName:UITextViewTextDidChangeNotification object:textView userInfo:nil];
+  XCTAssertTrue(textView.placeholderLabel.hidden);
+  [textView userSetText:@""];
+  XCTAssertTrue(textView.placeholderLabel.hidden);
+  [[NSNotificationCenter defaultCenter] postNotificationName:UITextViewTextDidChangeNotification object:textView userInfo:nil];
+  XCTAssertFalse(textView.placeholderLabel.hidden);
+  [[NSNotificationCenter defaultCenter] postNotificationName:UITextViewTextDidEndEditingNotification object:textView userInfo:nil];
+  XCTAssertFalse(textView.placeholderLabel.hidden);
 }
 
 @end


### PR DESCRIPTION
- Unify tabs/space across framework (2 spaces for ObjC, tabs for Swift)
- Make all pointers declaration as `<type> *<name>` (space after type; no space after identifier)
- Change all outlets from `weak` to `strong`